### PR TITLE
If no record.args, don't try % record.args

### DIFF
--- a/logistro/_api.py
+++ b/logistro/_api.py
@@ -66,7 +66,7 @@ class HumanFormatter(logging.Formatter):
         func = record.funcName or None
         if func:
             result += f":{func}()"
-        message = str(record.msg) % record.args
+        message = str(record.msg) % record.args if record.args else str(record.msg)
         result += f"- {message}"
         if record.exc_info:
             result += f"\n {' '.join(traceback.format_exception(*record.exc_info))}"


### PR DESCRIPTION
We have a problem with messages coming in from weird sources, unescaped. Python doesn't have a utility, afaik, for escaping format strings. I'm not even aware of all the special characters. `%` is one, I think there are more?

For now, since these sources don't often include arguments, if there are no arguments, don't use the `str % args` syntax.