### PR TITLE
Use a valid SPDX identifier as license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ name = "logistro"
 description = "Simple wrapper over logging for a couple basic features"
 dynamic = ["version"]
 readme = "README.md"
+license = "MIT"
 requires-python = ">=3.8"
 authors = [
   {name = "Andrew Pikul", email="ajpikul@gmail.com"},


### PR DESCRIPTION
This helps automatic license checkers like pip-licenses to identify the right license for this project